### PR TITLE
Fix: skip deleted node from url-test group (#1378)

### DIFF
--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -69,7 +69,13 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 		proxies := u.proxies(touch)
 		fast := proxies[0]
 		min := fast.LastDelay()
+		fastNotExist := true
+
 		for _, proxy := range proxies[1:] {
+			if u.fastNode != nil && proxy.Name() == u.fastNode.Name() {
+				fastNotExist = false
+			}
+
 			if !proxy.Alive() {
 				continue
 			}
@@ -82,7 +88,7 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 		}
 
 		// tolerance
-		if u.fastNode == nil || !u.fastNode.Alive() || u.fastNode.LastDelay() > fast.LastDelay()+u.tolerance {
+		if u.fastNode == nil || fastNotExist || !u.fastNode.Alive() || u.fastNode.LastDelay() > fast.LastDelay()+u.tolerance {
 			u.fastNode = fast
 		}
 


### PR DESCRIPTION
Update