### PR TITLE
Issue: DNS dns-hijack not work at macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ tun:
   stack: gvisor # System or gVisor
   # device: tun://utun8 # or fd://xxx, it's optional
   dns-hijack: 
-    - 0.0.0.0:53 # hijack all
+    - 0.0.0.0:53 # hijack all [not work at macos 12.x]
   auto-route: true # auto set global route
 ```
 ### Rules configuration


### PR DESCRIPTION
test on these config:
dns:
  enable: true
  ipv6: false
  listen: 0.0.0.0:8053
  enhanced-mode: redir-host

tun:
  enable: true
  stack: system #gvisor
  dns-hijack:
    - 0.0.0.0:53
  auto-route: true